### PR TITLE
Set nginx port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ collectd_server_owner: "ona"
 collectd_server_type: "generic"
 collectd_scripts: []
 collectd_user: "{{ ansible_ssh_user }}"
+collectd_nginx_port: 2182
 
 # RabbitMQ
 collectd_rabbitmq_admin_user: "admin"

--- a/templates/etc/collectd/collectd.conf.d/nginx.conf
+++ b/templates/etc/collectd/collectd.conf.d/nginx.conf
@@ -1,6 +1,6 @@
 LoadPlugin nginx
 <Plugin nginx>
-	URL "http://localhost/status?auto"
+	URL "http://localhost:{{ collectd_nginx_port }}/status?auto"
 #	User "www-user"
 #	Password "secret"
 #	CACert "/etc/ssl/ca.crt"


### PR DESCRIPTION
Using port 80 prevents health_checks from hitting the correct service.