### PR TITLE
Remove Hostname Configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ collectd_graphite_server_protocol: "tcp"
 collectd_server_owner: "ona"
 collectd_server_type: "generic"
 collectd_scripts: []
-collectd_user: "{{ ansible_ssh_user }}"
+collectd_user: "{{ ansible_user }}"
 
 # RabbitMQ
 collectd_rabbitmq_admin_user: "admin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,6 @@ collectd_server_mode: false
 collectd_graphite_server_ip: "127.0.0.1"
 collectd_graphite_server_port: 2003
 collectd_graphite_server_protocol: "tcp"
-collectd_server_hostname: "localhost"
 collectd_server_owner: "ona"
 collectd_server_type: "generic"
 collectd_scripts: []

--- a/templates/etc/collectd/collectd.conf.j2
+++ b/templates/etc/collectd/collectd.conf.j2
@@ -12,7 +12,6 @@
 # Global settings for the daemon.                                            #
 ##############################################################################
 
-Hostname "{{ collectd_server_hostname }}"
 FQDNLookup true
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"


### PR DESCRIPTION
So as to allow for collectd to auto-discover the hostname, rather than
having to set it in a configuration file, remove the Hostname variable
from the collectd.conf template.

Update the default collectd_user value from ansible_ssh_user to
ansible_user.