### PR TITLE
Update role to work on Ubuntu 22.04

### DIFF
--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,9 +6,9 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-devel python*-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python3 sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash python3-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,11 +4,33 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: ansible-collectd-ubuntu-18.04
-    image: solita/ubuntu-systemd:18.04
-    dockerfile: Dockerfile.j2
+  - name: ansible-rabbitmq-ubuntu-18.04
+    image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: true
     command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+  - name: ansible-rabbitmq-ubuntu-20.04
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+  - name: ansible-rabbitmq-ubuntu-22.04
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
 provisioner:
   name: ansible
 lint: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   get_url:
     url: http://launchpadlibrarian.net/587473820/collectd-core_5.12.0-9_amd64.deb
     dest: /tmp/collectd-core_5.12.0-9_amd64.deb
-  when: ansible_distribution_version is version("22.04", "=")
+  when: ansible_distribution_version == "22.04"
 
 - name: Ensure collectd-core is installed
   apt:
@@ -25,13 +25,13 @@
     state: present
   become: true
   become_user: root
-  when: ansible_distribution_version is version("22.04", "=")
+  when: ansible_distribution_version == "22.04"
 
 - name: Download collectd package
   get_url:
     url: http://launchpadlibrarian.net/587473817/collectd_5.12.0-9_amd64.deb
     dest: /tmp/collectd_5.12.0-9_amd64.deb
-  when: ansible_distribution_version is version("22.04", "=")
+  when: ansible_distribution_version == "22.04"
 
 - name: Ensure collectd is installed
   apt:
@@ -41,7 +41,7 @@
   become_user: root
   notify:
     - restart collectd
-  when: ansible_distribution_version is version("22.04", "=")
+  when: ansible_distribution_version == "22.04"
 
 - include_tasks: server_mode.yml
   when: collectd_server_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 
 # As of the time of this change collectd was not present for Ubuntu 22.04
 # This step uses a proposed change to update collectd for Ubuntu 22.04 and
-# may support all functionality
+# may not support all functionality
 # Conversation: https://bugs.launchpad.net/ubuntu/+source/collectd/+bug/1971093
 - name: Download collectd-core package
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,13 +15,13 @@
 # Conversation: https://bugs.launchpad.net/ubuntu/+source/collectd/+bug/1971093
 - name: Download collectd-core package
   get_url:
-    url: http://launchpadlibrarian.net/587473820/collectd-core_5.12.0-9_amd64.deb
-    dest: /tmp/collectd-core_5.12.0-9_amd64.deb
+    url: http://ftp.ubuntu.com/ubuntu/ubuntu/pool/universe/c/collectd/collectd-core_5.12.0-11_amd64.deb
+    dest: /tmp/collectd-core_5.12.0-11_amd64.deb
   when: ansible_distribution_version == "22.04"
 
 - name: Ensure collectd-core is installed
   apt:
-    deb: /tmp/collectd-core_5.12.0-9_amd64.deb
+    deb: /tmp/collectd-core_5.12.0-11_amd64.deb
     state: present
   become: true
   become_user: root
@@ -29,13 +29,13 @@
 
 - name: Download collectd package
   get_url:
-    url: http://launchpadlibrarian.net/587473817/collectd_5.12.0-9_amd64.deb
-    dest: /tmp/collectd_5.12.0-9_amd64.deb
+    url: http://ftp.ubuntu.com/ubuntu/ubuntu/pool/universe/c/collectd/collectd_5.12.0-11_amd64.deb
+    dest: /tmp/collectd_5.12.0-11_amd64.deb
   when: ansible_distribution_version == "22.04"
 
 - name: Ensure collectd is installed
   apt:
-    deb: /tmp/collectd_5.12.0-9_amd64.deb
+    deb: /tmp/collectd_5.12.0-11_amd64.deb
     state: present
   become: true
   become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,41 @@
     update_cache: true
   notify:
     - restart collectd
+  when: ansible_distribution_version is version("22.04", "<")
+
+# As of the time of this change collectd was not present for Ubuntu 22.04
+# This step uses a proposed change to update collectd for Ubuntu 22.04 and
+# may support all functionality
+# Conversation: https://bugs.launchpad.net/ubuntu/+source/collectd/+bug/1971093
+- name: Download collectd-core package
+  get_url:
+    url: http://launchpadlibrarian.net/587473820/collectd-core_5.12.0-9_amd64.deb
+    dest: /tmp/collectd-core_5.12.0-9_amd64.deb
+  when: ansible_distribution_version is version("22.04", "=")
+
+- name: Ensure collectd-core is installed
+  apt:
+    deb: /tmp/collectd-core_5.12.0-9_amd64.deb
+    state: present
+  become: true
+  become_user: root
+  when: ansible_distribution_version is version("22.04", "=")
+
+- name: Download collectd package
+  get_url:
+    url: http://launchpadlibrarian.net/587473817/collectd_5.12.0-9_amd64.deb
+    dest: /tmp/collectd_5.12.0-9_amd64.deb
+  when: ansible_distribution_version is version("22.04", "=")
+
+- name: Ensure collectd is installed
+  apt:
+    deb: /tmp/collectd_5.12.0-9_amd64.deb
+    state: present
+  become: true
+  become_user: root
+  notify:
+    - restart collectd
+  when: ansible_distribution_version is version("22.04", "=")
 
 - include_tasks: server_mode.yml
   when: collectd_server_mode


### PR DESCRIPTION
# Changes

- Install proposed collectd package for Ubuntu 22.04; Collectd is currently not available in the Ubuntu 22.04 repo. The package was yanked from the repo and seems to not yet fully support Ubuntu 22.04

